### PR TITLE
feat(patients): implementar vista de gestión con simulación CRUD

### DIFF
--- a/src/app/layout/component/app.menu.ts
+++ b/src/app/layout/component/app.menu.ts
@@ -81,9 +81,9 @@ export class AppMenu {
                         routerLink: ['/pages/crud']
                     },
                     {
-                        label: 'Paciente',
-                        icon: 'pi pi-fw pi-user',
-                        routerLink: ['/pages/paciente']
+                        label: 'Pacientes',
+                        icon: 'pi pi-fw pi-users',
+                        routerLink: ['/pages/pacientes']
                     },
                     {
                         label: 'Not Found',

--- a/src/app/pages/crud/crud.ts
+++ b/src/app/pages/crud/crud.ts
@@ -292,7 +292,7 @@ export class Crud implements OnInit {
                     severity: 'success',
                     summary: 'Successful',
                     detail: 'Products Deleted',
-                    life: 3000
+                    life: 1500
                 });
             }
         });
@@ -315,7 +315,7 @@ export class Crud implements OnInit {
                     severity: 'success',
                     summary: 'Successful',
                     detail: 'Product Deleted',
-                    life: 3000
+                    life: 1500
                 });
             }
         });
@@ -366,7 +366,7 @@ export class Crud implements OnInit {
                     severity: 'success',
                     summary: 'Successful',
                     detail: 'Product Updated',
-                    life: 3000
+                    life: 1500
                 });
             } else {
                 this.product.id = this.createId();
@@ -375,7 +375,7 @@ export class Crud implements OnInit {
                     severity: 'success',
                     summary: 'Successful',
                     detail: 'Product Created',
-                    life: 3000
+                    life: 1500
                 });
                 this.products.set([..._products, this.product]);
             }

--- a/src/app/pages/paciente/paciente.ts
+++ b/src/app/pages/paciente/paciente.ts
@@ -2,23 +2,19 @@ import { Component, OnInit, signal, ViewChild } from '@angular/core';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { Table, TableModule } from 'primeng/table';
 import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { ButtonModule } from 'primeng/button';
 import { RippleModule } from 'primeng/ripple';
 import { ToastModule } from 'primeng/toast';
 import { ToolbarModule } from 'primeng/toolbar';
-import { RatingModule } from 'primeng/rating';
 import { InputTextModule } from 'primeng/inputtext';
 import { TextareaModule } from 'primeng/textarea';
 import { SelectModule } from 'primeng/select';
-import { RadioButtonModule } from 'primeng/radiobutton';
-import { InputNumberModule } from 'primeng/inputnumber';
 import { DialogModule } from 'primeng/dialog';
-import { TagModule } from 'primeng/tag';
 import { InputIconModule } from 'primeng/inputicon';
 import { IconFieldModule } from 'primeng/iconfield';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
-import { Product, ProductService } from '../service/product.service';
+import { Patient, PatientService } from '../service/patient.service';
 
 interface Column {
     field: string;
@@ -32,84 +28,389 @@ interface ExportColumn {
 }
 
 @Component({
-    selector: 'app-crud',
+    selector: 'app-paciente',
     standalone: true,
     imports: [
         CommonModule,
         TableModule,
         FormsModule,
+        ReactiveFormsModule,
         ButtonModule,
         RippleModule,
         ToastModule,
         ToolbarModule,
-        RatingModule,
         InputTextModule,
         TextareaModule,
         SelectModule,
-        RadioButtonModule,
-        InputNumberModule,
         DialogModule,
-        TagModule,
         InputIconModule,
         IconFieldModule,
         ConfirmDialogModule
     ],
-    templateUrl: './paciente.html',
-    providers: [MessageService, ProductService, ConfirmationService]
+    template: `
+        <p-toolbar styleClass="mb-6">
+            <ng-template #start>
+                <p-button 
+                    label="Nuevo Paciente" 
+                    icon="pi pi-plus" 
+                    severity="secondary" 
+                    class="mr-2" 
+                    (onClick)="openNew()" 
+                />
+                <p-button 
+                    severity="secondary" 
+                    label="Eliminar Seleccionados" 
+                    icon="pi pi-trash" 
+                    outlined 
+                    (onClick)="deleteSelectedPatients()" 
+                    [disabled]="!selectedPatients || !selectedPatients.length" 
+                />
+            </ng-template>
+
+            <ng-template #end>
+                <p-button 
+                    label="Exportar" 
+                    icon="pi pi-upload" 
+                    severity="secondary" 
+                    (onClick)="exportCSV()" 
+                />
+            </ng-template>
+        </p-toolbar>
+
+        <p-table
+            #dt
+            [value]="patients()"
+            [rows]="10"
+            [columns]="cols"
+            [paginator]="true"
+            [globalFilterFields]="['nombreCompleto', 'cedula', 'correoElectronico', 'telefono']"
+            [tableStyle]="{ 'min-width': '75rem' }"
+            [(selection)]="selectedPatients"
+            [rowHover]="true"
+            dataKey="id"
+            currentPageReportTemplate="Mostrando {first} a {last} de {totalRecords} pacientes"
+            [showCurrentPageReport]="true"
+            [rowsPerPageOptions]="[10, 20, 30]"
+        >
+            <ng-template #caption>
+                <div class="flex items-center justify-between">
+                    <h5 class="m-0">Gestión de Pacientes</h5>
+                    <p-iconfield>
+                        <p-inputicon styleClass="pi pi-search" />
+                        <input 
+                            pInputText 
+                            type="text" 
+                            (input)="onGlobalFilter(dt, $event)" 
+                            placeholder="Buscar por nombre, cédula o correo..." 
+                        />
+                    </p-iconfield>
+                </div>
+            </ng-template>
+            
+            <ng-template #header>
+                <tr>
+                    <th style="width: 3rem">
+                        <p-tableHeaderCheckbox />
+                    </th>
+                    <th pSortableColumn="nombreCompleto" style="min-width: 20rem">
+                        Nombre Completo
+                        <p-sortIcon field="nombreCompleto" />
+                    </th>
+                    <th pSortableColumn="cedula" style="min-width: 12rem">
+                        Cédula
+                        <p-sortIcon field="cedula" />
+                    </th>
+                    <th pSortableColumn="telefono" style="min-width: 12rem">
+                        Teléfono
+                        <p-sortIcon field="telefono" />
+                    </th>
+                    <th pSortableColumn="correoElectronico" style="min-width: 16rem">
+                        Correo Electrónico
+                        <p-sortIcon field="correoElectronico" />
+                    </th>
+                    <th pSortableColumn="genero" style="min-width: 10rem">
+                        Género
+                        <p-sortIcon field="genero" />
+                    </th>
+                    <th style="min-width: 12rem">Acciones</th>
+                </tr>
+            </ng-template>
+            
+            <ng-template #body let-patient>
+                <tr>
+                    <td style="width: 3rem">
+                        <p-tableCheckbox [value]="patient" />
+                    </td>
+                    <td style="min-width: 20rem">{{ patient.nombreCompleto }}</td>
+                    <td style="min-width: 12rem">{{ patient.cedula }}</td>
+                    <td style="min-width: 12rem">{{ patient.telefono }}</td>
+                    <td style="min-width: 16rem">{{ patient.correoElectronico }}</td>
+                    <td style="min-width: 10rem">{{ patient.genero }}</td>
+                    <td>
+                        <p-button 
+                            icon="pi pi-pencil" 
+                            class="mr-2" 
+                            [rounded]="true" 
+                            [outlined]="true" 
+                            (click)="editPatient(patient)" 
+                        />
+                        <p-button 
+                            icon="pi pi-trash" 
+                            severity="danger" 
+                            [rounded]="true" 
+                            [outlined]="true" 
+                            (click)="deletePatient(patient)" 
+                        />
+                    </td>
+                </tr>
+            </ng-template>
+        </p-table>
+
+        <p-dialog 
+            [(visible)]="patientDialog" 
+            [style]="{ width: '600px' }" 
+            [header]="isEditMode ? 'Editar Paciente' : 'Nuevo Paciente'" 
+            [modal]="true"
+            [closable]="true"
+        >
+            <ng-template #content>
+                <form [formGroup]="patientForm" class="flex flex-col gap-4">
+                    <div class="grid grid-cols-12 gap-4">
+                        <div class="col-span-12">
+                            <label for="nombreCompleto" class="block font-bold mb-2">Nombre Completo *</label>
+                            <input 
+                                type="text" 
+                                pInputText 
+                                id="nombreCompleto" 
+                                formControlName="nombreCompleto"
+                                placeholder="Ingrese el nombre completo"
+                                [class.ng-invalid]="submitted && patientForm.get('nombreCompleto')?.invalid"
+                                fluid 
+                            />
+                            <small 
+                                class="text-red-500" 
+                                *ngIf="submitted && patientForm.get('nombreCompleto')?.errors?.['required']"
+                            >
+                                El nombre completo es requerido.
+                            </small>
+                        </div>
+                    </div>
+
+                    <div class="grid grid-cols-12 gap-4">
+                        <div class="col-span-6">
+                            <label for="cedula" class="block font-bold mb-2">Cédula *</label>
+                            <input 
+                                type="text" 
+                                pInputText 
+                                id="cedula" 
+                                formControlName="cedula"
+                                placeholder="Número de cédula"
+                                [class.ng-invalid]="submitted && patientForm.get('cedula')?.invalid"
+                                fluid 
+                            />
+                            <small 
+                                class="text-red-500" 
+                                *ngIf="submitted && patientForm.get('cedula')?.errors?.['required']"
+                            >
+                                La cédula es requerida.
+                            </small>
+                        </div>
+                        <div class="col-span-6">
+                            <label for="fechaNacimiento" class="block font-bold mb-2">Fecha de Nacimiento *</label>
+                            <input 
+                                type="date" 
+                                pInputText 
+                                id="fechaNacimiento" 
+                                formControlName="fechaNacimiento"
+                                [max]="maxDate.toISOString().split('T')[0]"
+                                [class.ng-invalid]="submitted && patientForm.get('fechaNacimiento')?.invalid"
+                                fluid
+                            />
+                            <small 
+                                class="text-red-500" 
+                                *ngIf="submitted && patientForm.get('fechaNacimiento')?.errors?.['required']"
+                            >
+                                La fecha de nacimiento es requerida.
+                            </small>
+                        </div>
+                    </div>
+
+                    <div class="grid grid-cols-12 gap-4">
+                        <div class="col-span-6">
+                            <label for="genero" class="block font-bold mb-2">Género *</label>
+                            <p-select 
+                                id="genero" 
+                                formControlName="genero"
+                                [options]="generoOptions" 
+                                optionLabel="label" 
+                                optionValue="value" 
+                                placeholder="Seleccione género"
+                                [class.ng-invalid]="submitted && patientForm.get('genero')?.invalid"
+                                fluid 
+                            />
+                            <small 
+                                class="text-red-500" 
+                                *ngIf="submitted && patientForm.get('genero')?.errors?.['required']"
+                            >
+                                El género es requerido.
+                            </small>
+                        </div>
+                        <div class="col-span-6">
+                            <label for="telefono" class="block font-bold mb-2">Teléfono *</label>
+                            <input 
+                                type="tel" 
+                                pInputText 
+                                id="telefono" 
+                                formControlName="telefono"
+                                placeholder="Número de teléfono"
+                                [class.ng-invalid]="submitted && patientForm.get('telefono')?.invalid"
+                                fluid 
+                            />
+                            <small 
+                                class="text-red-500" 
+                                *ngIf="submitted && patientForm.get('telefono')?.errors?.['required']"
+                            >
+                                El teléfono es requerido.
+                            </small>
+                        </div>
+                    </div>
+
+                    <div class="grid grid-cols-12 gap-4">
+                        <div class="col-span-12">
+                            <label for="correoElectronico" class="block font-bold mb-2">Correo Electrónico *</label>
+                            <input 
+                                type="email" 
+                                pInputText 
+                                id="correoElectronico" 
+                                formControlName="correoElectronico"
+                                placeholder="correo@ejemplo.com"
+                                [class.ng-invalid]="submitted && patientForm.get('correoElectronico')?.invalid"
+                                fluid 
+                            />
+                            <small 
+                                class="text-red-500" 
+                                *ngIf="submitted && patientForm.get('correoElectronico')?.errors?.['required']"
+                            >
+                                El correo electrónico es requerido.
+                            </small>
+                            <small 
+                                class="text-red-500" 
+                                *ngIf="submitted && patientForm.get('correoElectronico')?.errors?.['email']"
+                            >
+                                Ingrese un correo electrónico válido.
+                            </small>
+                        </div>
+                    </div>
+
+                    <div class="grid grid-cols-12 gap-4">
+                        <div class="col-span-12">
+                            <label for="direccion" class="block font-bold mb-2">Dirección *</label>
+                            <p-textarea 
+                                id="direccion" 
+                                formControlName="direccion"
+                                placeholder="Ingrese la dirección completa"
+                                rows="3"
+                                [class.ng-invalid]="submitted && patientForm.get('direccion')?.invalid"
+                                fluid
+                            />
+                            <small 
+                                class="text-red-500" 
+                                *ngIf="submitted && patientForm.get('direccion')?.errors?.['required']"
+                            >
+                                La dirección es requerida.
+                            </small>
+                        </div>
+                    </div>
+                </form>
+            </ng-template>
+
+            <ng-template #footer>
+                <p-button 
+                    label="Cancelar" 
+                    icon="pi pi-times" 
+                    text 
+                    (click)="hideDialog()" 
+                />
+                <p-button 
+                    [label]="isEditMode ? 'Actualizar' : 'Guardar'" 
+                    icon="pi pi-check" 
+                    (click)="savePatient()" 
+                />
+            </ng-template>
+        </p-dialog>
+
+        <p-confirmdialog [style]="{ width: '450px' }" />
+        <p-toast />
+    `,
+    providers: [MessageService, PatientService, ConfirmationService]
 })
 export class Paciente implements OnInit {
-    productDialog: boolean = false;
-
-    products = signal<Product[]>([]);
-
-    product!: Product;
-
-    selectedProducts!: Product[] | null;
-
+    patientDialog: boolean = false;
+    isEditMode: boolean = false;
+    patients = signal<Patient[]>([]);
+    patient!: Patient;
+    selectedPatients!: Patient[] | null;
     submitted: boolean = false;
-
-    statuses!: any[];
+    maxDate: Date = new Date();
 
     @ViewChild('dt') dt!: Table;
 
     exportColumns!: ExportColumn[];
-
     cols!: Column[];
 
-    constructor(
-        private productService: ProductService,
-        private messageService: MessageService,
-        private confirmationService: ConfirmationService
-    ) {}
+    patientForm: FormGroup;
 
-    exportCSV() {
-        this.dt.exportCSV();
+    generoOptions = [
+        { label: 'Masculino', value: 'Masculino' },
+        { label: 'Femenino', value: 'Femenino' },
+        { label: 'Otro', value: 'Otro' }
+    ];
+
+    constructor(
+        private patientService: PatientService,
+        private messageService: MessageService,
+        private confirmationService: ConfirmationService,
+        private fb: FormBuilder
+    ) {
+        this.patientForm = this.fb.group({
+            nombreCompleto: ['', [Validators.required, Validators.minLength(2)]],
+            cedula: ['', [Validators.required, Validators.pattern(/^\d{7,10}$/)]],
+            fechaNacimiento: ['', Validators.required],
+            genero: ['', Validators.required],
+            direccion: ['', [Validators.required, Validators.minLength(10)]],
+            telefono: ['', [Validators.required, Validators.pattern(/^[0-9+\-\s()]+$/)]],
+            correoElectronico: ['', [Validators.required, Validators.email]]
+        });
     }
 
     ngOnInit() {
-        this.loadDemoData();
+        this.loadPatients();
+        this.setupTableColumns();
     }
 
-    loadDemoData() {
-        this.productService.getProducts().then((data) => {
-            this.products.set(data);
+    loadPatients() {
+        this.patientService.getPatients().then((data) => {
+            this.patients.set(data);
         });
+    }
 
-        this.statuses = [
-            { label: 'INSTOCK', value: 'instock' },
-            { label: 'LOWSTOCK', value: 'lowstock' },
-            { label: 'OUTOFSTOCK', value: 'outofstock' }
-        ];
-
+    setupTableColumns() {
         this.cols = [
-            { field: 'code', header: 'Code', customExportHeader: 'Product Code' },
-            { field: 'name', header: 'Name' },
-            { field: 'image', header: 'Image' },
-            { field: 'price', header: 'Price' },
-            { field: 'category', header: 'Category' }
+            { field: 'nombreCompleto', header: 'Nombre Completo' },
+            { field: 'cedula', header: 'Cédula' },
+            { field: 'telefono', header: 'Teléfono' },
+            { field: 'correoElectronico', header: 'Correo Electrónico' },
+            { field: 'genero', header: 'Género' }
         ];
 
-        this.exportColumns = this.cols.map((col) => ({ title: col.header, dataKey: col.field }));
+        this.exportColumns = this.cols.map((col) => ({ 
+            title: col.header, 
+            dataKey: col.field 
+        }));
+    }
+
+    exportCSV() {
+        this.dt.exportCSV();
     }
 
     onGlobalFilter(table: Table, event: Event) {
@@ -117,28 +418,51 @@ export class Paciente implements OnInit {
     }
 
     openNew() {
-        this.product = {};
+        this.isEditMode = false;
+        this.patient = {
+            nombreCompleto: '',
+            cedula: '',
+            fechaNacimiento: new Date(),
+            genero: '',
+            direccion: '',
+            telefono: '',
+            correoElectronico: ''
+        };
         this.submitted = false;
-        this.productDialog = true;
+        this.patientForm.reset();
+        this.patientDialog = true;
     }
 
-    editProduct(product: Product) {
-        this.product = { ...product };
-        this.productDialog = true;
+    editPatient(patient: Patient) {
+        this.isEditMode = true;
+        this.patient = { ...patient };
+        this.submitted = false;
+        
+        this.patientForm.patchValue({
+            nombreCompleto: patient.nombreCompleto,
+            cedula: patient.cedula,
+            fechaNacimiento: new Date(patient.fechaNacimiento).toISOString().split('T')[0],
+            genero: patient.genero,
+            direccion: patient.direccion,
+            telefono: patient.telefono,
+            correoElectronico: patient.correoElectronico
+        });
+        
+        this.patientDialog = true;
     }
 
-    deleteSelectedProducts() {
+    deleteSelectedPatients() {
         this.confirmationService.confirm({
-            message: 'Are you sure you want to delete the selected products?',
-            header: 'Confirm',
+            message: '¿Está seguro de que desea eliminar los pacientes seleccionados?',
+            header: 'Confirmar',
             icon: 'pi pi-exclamation-triangle',
             accept: () => {
-                this.products.set(this.products().filter((val) => !this.selectedProducts?.includes(val)));
-                this.selectedProducts = null;
+                this.patients.set(this.patients().filter((val) => !this.selectedPatients?.includes(val)));
+                this.selectedPatients = null;
                 this.messageService.add({
                     severity: 'success',
-                    summary: 'Successful',
-                    detail: 'Products Deleted',
+                    summary: 'Éxito',
+                    detail: 'Pacientes eliminados correctamente',
                     life: 3000
                 });
             }
@@ -146,89 +470,78 @@ export class Paciente implements OnInit {
     }
 
     hideDialog() {
-        this.productDialog = false;
+        this.patientDialog = false;
         this.submitted = false;
+        this.patientForm.reset();
     }
 
-    deleteProduct(product: Product) {
+    deletePatient(patient: Patient) {
         this.confirmationService.confirm({
-            message: 'Are you sure you want to delete ' + product.name + '?',
-            header: 'Confirm',
+            message: '¿Está seguro de que desea eliminar a ' + patient.nombreCompleto + '?',
+            header: 'Confirmar',
             icon: 'pi pi-exclamation-triangle',
             accept: () => {
-                this.products.set(this.products().filter((val) => val.id !== product.id));
-                this.product = {};
-                this.messageService.add({
-                    severity: 'success',
-                    summary: 'Successful',
-                    detail: 'Product Deleted',
-                    life: 3000
+                this.patientService.deletePatient(patient.id!).then((success) => {
+                    if (success) {
+                        this.patients.set(this.patients().filter((val) => val.id !== patient.id));
+                        this.messageService.add({
+                            severity: 'success',
+                            summary: 'Éxito',
+                            detail: 'Paciente eliminado correctamente',
+                            life: 3000
+                        });
+                    }
                 });
             }
         });
     }
 
-    findIndexById(id: string): number {
-        let index = -1;
-        for (let i = 0; i < this.products().length; i++) {
-            if (this.products()[i].id === id) {
-                index = i;
-                break;
-            }
-        }
-
-        return index;
-    }
-
-    createId(): string {
-        let id = '';
-        var chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-        for (var i = 0; i < 5; i++) {
-            id += chars.charAt(Math.floor(Math.random() * chars.length));
-        }
-        return id;
-    }
-
-    getSeverity(status: string) {
-        switch (status) {
-            case 'INSTOCK':
-                return 'success';
-            case 'LOWSTOCK':
-                return 'warn';
-            case 'OUTOFSTOCK':
-                return 'danger';
-            default:
-                return 'info';
-        }
-    }
-
-    saveProduct() {
+    savePatient() {
         this.submitted = true;
-        let _products = this.products();
-        if (this.product.name?.trim()) {
-            if (this.product.id) {
-                _products[this.findIndexById(this.product.id)] = this.product;
-                this.products.set([..._products]);
-                this.messageService.add({
-                    severity: 'success',
-                    summary: 'Successful',
-                    detail: 'Product Updated',
-                    life: 3000
+
+        if (this.patientForm.valid) {
+            const formValue = this.patientForm.value;
+            const patientData: Patient = {
+                ...formValue,
+                fechaNacimiento: new Date(formValue.fechaNacimiento),
+                id: this.isEditMode ? this.patient.id : undefined
+            };
+
+            if (this.isEditMode) {
+                this.patientService.updatePatient(patientData).then((updatedPatient) => {
+                    const index = this.patients().findIndex(p => p.id === updatedPatient.id);
+                    if (index !== -1) {
+                        const updatedPatients = [...this.patients()];
+                        updatedPatients[index] = updatedPatient;
+                        this.patients.set(updatedPatients);
+                    }
+                    this.messageService.add({
+                        severity: 'success',
+                        summary: 'Éxito',
+                        detail: 'Paciente actualizado correctamente',
+                        life: 3000
+                    });
+                    this.hideDialog();
                 });
             } else {
-                this.product.id = this.createId();
-                this.product.image = 'product-placeholder.svg';
-                this.messageService.add({
-                    severity: 'success',
-                    summary: 'Successful',
-                    detail: 'Product Created',
-                    life: 3000
+                this.patientService.createPatient(patientData).then((newPatient) => {
+                    this.patients.set([...this.patients(), newPatient]);
+                    this.messageService.add({
+                        severity: 'success',
+                        summary: 'Éxito',
+                        detail: 'Paciente creado correctamente',
+                        life: 3000
+                    });
+                    this.hideDialog();
                 });
-                this.products.set([..._products, this.product]);
             }
-
-            this.productDialog = false;
-            this.product = {};
+        } else {
+            this.messageService.add({
+                severity: 'error',
+                summary: 'Error',
+                detail: 'Por favor complete todos los campos requeridos correctamente',
+                life: 3000
+            });
         }
     }
 }

--- a/src/app/pages/paciente/paciente.ts
+++ b/src/app/pages/paciente/paciente.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, signal, ViewChild } from '@angular/core';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { Table, TableModule } from 'primeng/table';
 import { CommonModule } from '@angular/common';
-import { FormsModule, ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule, FormBuilder, FormGroup, Validators, AbstractControl, ValidationErrors, AsyncValidatorFn } from '@angular/forms';
 import { ButtonModule } from 'primeng/button';
 import { RippleModule } from 'primeng/ripple';
 import { ToastModule } from 'primeng/toast';
@@ -15,6 +15,7 @@ import { InputIconModule } from 'primeng/inputicon';
 import { IconFieldModule } from 'primeng/iconfield';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { Patient, PatientService } from '../service/patient.service';
+import { Observable, map } from 'rxjs';
 
 interface Column {
     field: string;
@@ -25,6 +26,25 @@ interface Column {
 interface ExportColumn {
     title: string;
     dataKey: string;
+}
+
+// Validadores personalizados para campos únicos
+function createUniqueValidator(
+    validatorFn: (value: string, excludeId?: string) => Promise<boolean>,
+    excludeId?: string
+): AsyncValidatorFn {
+    return (control: AbstractControl): Observable<ValidationErrors | null> => {
+        if (!control.value) {
+            return new Observable(observer => observer.next(null));
+        }
+        
+        return new Observable(observer => {
+            validatorFn(control.value, excludeId).then(isUnique => {
+                observer.next(isUnique ? null : { unique: true });
+                observer.complete();
+            });
+        });
+    };
 }
 
 @Component({
@@ -187,12 +207,18 @@ interface ExportColumn {
                                 [class.ng-invalid]="submitted && patientForm.get('nombreCompleto')?.invalid"
                                 fluid 
                             />
-                            <small 
-                                class="text-red-500" 
-                                *ngIf="submitted && patientForm.get('nombreCompleto')?.errors?.['required']"
-                            >
-                                El nombre completo es requerido.
-                            </small>
+                             <small 
+                                 class="text-red-500" 
+                                 *ngIf="submitted && patientForm.get('nombreCompleto')?.errors?.['required']"
+                             >
+                                 El nombre completo es requerido.
+                             </small>
+                             <small 
+                                 class="text-red-500" 
+                                 *ngIf="patientForm.get('nombreCompleto')?.errors?.['unique']"
+                             >
+                                 Este nombre completo ya está registrado.
+                             </small>
                         </div>
                     </div>
 
@@ -215,12 +241,18 @@ interface ExportColumn {
                             >
                                 La cédula es requerida.
                             </small>
-                            <small 
-                                class="text-red-500" 
-                                *ngIf="submitted && patientForm.get('cedula')?.errors?.['pattern']"
-                            >
-                                La cédula debe tener el formato XXX-XXXXXXX-X (11 dígitos).
-                            </small>
+                             <small 
+                                 class="text-red-500" 
+                                 *ngIf="submitted && patientForm.get('cedula')?.errors?.['pattern']"
+                             >
+                                 La cédula debe tener el formato XXX-XXXXXXX-X (11 dígitos).
+                             </small>
+                             <small 
+                                 class="text-red-500" 
+                                 *ngIf="patientForm.get('cedula')?.errors?.['unique']"
+                             >
+                                 Esta cédula ya está registrada.
+                             </small>
                         </div>
                         <div class="col-span-6">
                             <label for="fechaNacimiento" class="block font-bold mb-2">Fecha de Nacimiento *</label>
@@ -300,12 +332,18 @@ interface ExportColumn {
                             >
                                 El correo electrónico es requerido.
                             </small>
-                            <small 
-                                class="text-red-500" 
-                                *ngIf="submitted && patientForm.get('correoElectronico')?.errors?.['email']"
-                            >
-                                Ingrese un correo electrónico válido.
-                            </small>
+                             <small 
+                                 class="text-red-500" 
+                                 *ngIf="submitted && patientForm.get('correoElectronico')?.errors?.['email']"
+                             >
+                                 Ingrese un correo electrónico válido.
+                             </small>
+                             <small 
+                                 class="text-red-500" 
+                                 *ngIf="patientForm.get('correoElectronico')?.errors?.['unique']"
+                             >
+                                 Este correo electrónico ya está registrado.
+                             </small>
                         </div>
                     </div>
 
@@ -387,13 +425,22 @@ export class Paciente implements OnInit {
         private fb: FormBuilder
     ) {
         this.patientForm = this.fb.group({
-            nombreCompleto: ['', [Validators.required, Validators.minLength(2)]],
-            cedula: ['', [Validators.required, Validators.pattern(/^\d{3}-\d{7}-\d{1}$/)]],
+            nombreCompleto: ['', 
+                [Validators.required, Validators.minLength(2)], 
+                [createUniqueValidator(this.patientService.isNombreCompletoUnique.bind(this.patientService))]
+            ],
+            cedula: ['', 
+                [Validators.required, Validators.pattern(/^\d{3}-\d{7}-\d{1}$/)], 
+                [createUniqueValidator(this.patientService.isCedulaUnique.bind(this.patientService))]
+            ],
             fechaNacimiento: ['', Validators.required],
             genero: ['', Validators.required],
             direccion: ['', [Validators.required, Validators.minLength(10)]],
             telefono: ['', [Validators.required, Validators.pattern(/^[0-9+\-\s()]+$/)]],
-            correoElectronico: ['', [Validators.required, Validators.email]]
+            correoElectronico: ['', 
+                [Validators.required, Validators.email], 
+                [createUniqueValidator(this.patientService.isCorreoElectronicoUnique.bind(this.patientService))]
+            ]
         });
     }
 
@@ -454,6 +501,32 @@ export class Paciente implements OnInit {
         }
     }
 
+    updateValidatorsForNew() {
+        // Para nuevos pacientes, no excluir ningún ID
+        this.patientForm.get('nombreCompleto')?.setAsyncValidators([
+            createUniqueValidator(this.patientService.isNombreCompletoUnique.bind(this.patientService))
+        ]);
+        this.patientForm.get('cedula')?.setAsyncValidators([
+            createUniqueValidator(this.patientService.isCedulaUnique.bind(this.patientService))
+        ]);
+        this.patientForm.get('correoElectronico')?.setAsyncValidators([
+            createUniqueValidator(this.patientService.isCorreoElectronicoUnique.bind(this.patientService))
+        ]);
+    }
+
+    updateValidatorsForEdit(excludeId?: string) {
+        // Para edición, excluir el ID del paciente actual
+        this.patientForm.get('nombreCompleto')?.setAsyncValidators([
+            createUniqueValidator(this.patientService.isNombreCompletoUnique.bind(this.patientService), excludeId)
+        ]);
+        this.patientForm.get('cedula')?.setAsyncValidators([
+            createUniqueValidator(this.patientService.isCedulaUnique.bind(this.patientService), excludeId)
+        ]);
+        this.patientForm.get('correoElectronico')?.setAsyncValidators([
+            createUniqueValidator(this.patientService.isCorreoElectronicoUnique.bind(this.patientService), excludeId)
+        ]);
+    }
+
     exportCSV() {
         this.dt.exportCSV();
     }
@@ -474,6 +547,7 @@ export class Paciente implements OnInit {
             correoElectronico: ''
         };
         this.submitted = false;
+        this.updateValidatorsForNew();
         this.patientForm.reset();
         this.patientDialog = true;
     }
@@ -482,6 +556,9 @@ export class Paciente implements OnInit {
         this.isEditMode = true;
         this.patient = { ...patient };
         this.submitted = false;
+        
+        // Actualizar los validadores para excluir el ID del paciente actual
+        this.updateValidatorsForEdit(patient.id);
         
         this.patientForm.patchValue({
             nombreCompleto: patient.nombreCompleto,
@@ -544,6 +621,11 @@ export class Paciente implements OnInit {
     savePatient() {
         this.submitted = true;
 
+        // Marcar todos los campos como tocados para mostrar errores
+        Object.keys(this.patientForm.controls).forEach(key => {
+            this.patientForm.get(key)?.markAsTouched();
+        });
+
         if (this.patientForm.valid) {
             const formValue = this.patientForm.value;
             const patientData: Patient = {
@@ -581,12 +663,27 @@ export class Paciente implements OnInit {
                 });
             }
         } else {
-            this.messageService.add({
-                severity: 'error',
-                summary: 'Error',
-                detail: 'Por favor complete todos los campos requeridos correctamente',
-                life: 3000
+            // Verificar si hay errores de unicidad
+            const hasUniqueErrors = Object.keys(this.patientForm.controls).some(key => {
+                const control = this.patientForm.get(key);
+                return control?.errors?.['unique'];
             });
+
+            if (hasUniqueErrors) {
+                this.messageService.add({
+                    severity: 'error',
+                    summary: 'Error',
+                    detail: 'Algunos campos ya están registrados en el sistema',
+                    life: 3000
+                });
+            } else {
+                this.messageService.add({
+                    severity: 'error',
+                    summary: 'Error',
+                    detail: 'Por favor complete todos los campos requeridos correctamente',
+                    life: 3000
+                });
+            }
         }
     }
 }

--- a/src/app/pages/paciente/paciente.ts
+++ b/src/app/pages/paciente/paciente.ts
@@ -463,7 +463,7 @@ export class Paciente implements OnInit {
                     severity: 'success',
                     summary: 'Éxito',
                     detail: 'Pacientes eliminados correctamente',
-                    life: 3000
+                    life: 1500
                 });
             }
         });
@@ -488,7 +488,7 @@ export class Paciente implements OnInit {
                             severity: 'success',
                             summary: 'Éxito',
                             detail: 'Paciente eliminado correctamente',
-                            life: 3000
+                            life: 1500
                         });
                     }
                 });
@@ -519,7 +519,7 @@ export class Paciente implements OnInit {
                         severity: 'success',
                         summary: 'Éxito',
                         detail: 'Paciente actualizado correctamente',
-                        life: 3000
+                        life: 1500
                     });
                     this.hideDialog();
                 });
@@ -530,7 +530,7 @@ export class Paciente implements OnInit {
                         severity: 'success',
                         summary: 'Éxito',
                         detail: 'Paciente creado correctamente',
-                        life: 3000
+                        life: 1500
                     });
                     this.hideDialog();
                 });

--- a/src/app/pages/paciente/paciente.ts
+++ b/src/app/pages/paciente/paciente.ts
@@ -221,9 +221,6 @@ interface ExportColumn {
                             >
                                 La cédula debe tener el formato XXX-XXXXXXX-X (11 dígitos).
                             </small>
-                            <small class="text-gray-600">
-                                Formato: XXX-XXXXXXX-X (se formatea automáticamente)
-                            </small>
                         </div>
                         <div class="col-span-6">
                             <label for="fechaNacimiento" class="block font-bold mb-2">Fecha de Nacimiento *</label>

--- a/src/app/pages/paciente/paciente.ts
+++ b/src/app/pages/paciente/paciente.ts
@@ -195,6 +195,7 @@ function createUniqueValidator(
             [closable]="true"
             [draggable]="false"
             [resizable]="false"
+            [styleClass]="'patient-form-dialog'"
         >
             <ng-template #content>
                 <form [formGroup]="patientForm" class="flex flex-col gap-4">
@@ -408,66 +409,66 @@ function createUniqueValidator(
             <ng-template #content>
                 <div class="grid grid-cols-12 gap-4" *ngIf="patient">
                     <div class="col-span-12">
-                        <div class="bg-gray-50 p-4 rounded-lg">
+                        <div class="bg-surface-0 dark:bg-surface-900 p-4 rounded-lg">
                             <div class="text-center mb-6">
                                     <i class="pi pi-user text-8xl text-blue-500 mb-3 block" style="font-size: 5rem;"></i>
-                                <h3 class="text-xl font-bold text-gray-800">{{ patient.nombreCompleto }}</h3>
+                                <h3 class="text-xl font-bold text-surface-900 dark:text-surface-0">{{ patient.nombreCompleto }}</h3>
                             </div>
                             
                             <div class="grid grid-cols-1 gap-4">
                                 <div class="flex items-center">
-                                    <i class="pi pi-id-card text-gray-600 mr-3"></i>
+                                    <i class="pi pi-id-card text-surface-600 dark:text-surface-400 mr-3"></i>
                                     <div class="flex flex-col">
-                                        <span class="font-bold text-lg text-gray-800">Cédula</span>
-                                        <span class="text-gray-700">{{ patient.cedula }}</span>
+                                        <span class="font-bold text-lg text-surface-900 dark:text-surface-0">Cédula</span>
+                                        <span class="text-surface-700 dark:text-surface-300">{{ patient.cedula }}</span>
                                     </div>
                                 </div>
                                 
                                 <div class="flex items-center">
-                                    <i class="pi pi-calendar text-gray-600 mr-3"></i>
+                                    <i class="pi pi-calendar text-surface-600 dark:text-surface-400 mr-3"></i>
                                     <div class="flex flex-col">
-                                        <span class="font-bold text-lg text-gray-800">Fecha de Nacimiento</span>
-                                        <span class="text-gray-700">{{ patient.fechaNacimiento | date:'dd/MM/yyyy' }}</span>
+                                        <span class="font-bold text-lg text-surface-900 dark:text-surface-0">Fecha de Nacimiento</span>
+                                        <span class="text-surface-700 dark:text-surface-300">{{ patient.fechaNacimiento | date:'dd/MM/yyyy' }}</span>
                                     </div>
                                 </div>
                                 
                                 <div class="flex items-center">
-                                    <i class="pi pi-users text-gray-600 mr-3"></i>
+                                    <i class="pi pi-users text-surface-600 dark:text-surface-400 mr-3"></i>
                                     <div class="flex flex-col">
-                                        <span class="font-bold text-lg text-gray-800">Género</span>
-                                        <span class="text-gray-700">{{ patient.genero }}</span>
+                                        <span class="font-bold text-lg text-surface-900 dark:text-surface-0">Género</span>
+                                        <span class="text-surface-700 dark:text-surface-300">{{ patient.genero }}</span>
                                     </div>
                                 </div>
                                 
                                 <div class="flex items-center">
-                                    <i class="pi pi-phone text-gray-600 mr-3"></i>
+                                    <i class="pi pi-phone text-surface-600 dark:text-surface-400 mr-3"></i>
                                     <div class="flex flex-col">
-                                        <span class="font-bold text-lg text-gray-800">Teléfono</span>
-                                        <span class="text-gray-700">{{ patient.telefono }}</span>
+                                        <span class="font-bold text-lg text-surface-900 dark:text-surface-0">Teléfono</span>
+                                        <span class="text-surface-700 dark:text-surface-300">{{ patient.telefono }}</span>
                                     </div>
                                 </div>
                                 
                                 <div class="flex items-center">
-                                    <i class="pi pi-envelope text-gray-600 mr-3"></i>
+                                    <i class="pi pi-envelope text-surface-600 dark:text-surface-400 mr-3"></i>
                                     <div class="flex flex-col">
-                                        <span class="font-bold text-lg text-gray-800">Correo Electrónico</span>
-                                        <span class="text-gray-700">{{ patient.correoElectronico }}</span>
+                                        <span class="font-bold text-lg text-surface-900 dark:text-surface-0">Correo Electrónico</span>
+                                        <span class="text-surface-700 dark:text-surface-300">{{ patient.correoElectronico }}</span>
                                     </div>
                                 </div>
                                 
                                 <div class="flex items-start">
-                                    <i class="pi pi-map-marker text-gray-600 mr-3 mt-2"></i>
+                                    <i class="pi pi-map-marker text-surface-600 dark:text-surface-400 mr-3 mt-2"></i>
                                     <div class="flex flex-col">
-                                        <span class="font-bold text-lg text-gray-800">Dirección</span>
-                                        <span class="text-gray-700">{{ patient.direccion }}</span>
+                                        <span class="font-bold text-lg text-surface-900 dark:text-surface-0">Dirección</span>
+                                        <span class="text-surface-700 dark:text-surface-300">{{ patient.direccion }}</span>
                                     </div>
                                 </div>
                                 
                                 <div class="flex items-center" *ngIf="patient.fechaRegistro">
-                                    <i class="pi pi-clock text-gray-600 mr-3"></i>
+                                    <i class="pi pi-clock text-surface-600 dark:text-surface-400 mr-3"></i>
                                     <div class="flex flex-col">
-                                        <span class="font-bold text-lg text-gray-800">Fecha de Registro</span>
-                                        <span class="text-gray-700">{{ patient.fechaRegistro | date:'dd/MM/yyyy HH:mm' }}</span>
+                                        <span class="font-bold text-lg text-surface-900 dark:text-surface-0">Fecha de Registro</span>
+                                        <span class="text-surface-700 dark:text-surface-300">{{ patient.fechaRegistro | date:'dd/MM/yyyy HH:mm' }}</span>
                                     </div>
                                 </div>
                             </div>
@@ -513,7 +514,8 @@ function createUniqueValidator(
             justify-content: flex-end;
         }
         
-        :host ::ng-deep .patient-details-dialog .p-dialog-content .bg-gray-50 {
+        :host ::ng-deep .patient-details-dialog .p-dialog-content .bg-surface-0,
+        :host ::ng-deep .patient-details-dialog .p-dialog-content .dark\\:bg-surface-900 {
             margin-bottom: 0;
         }
         

--- a/src/app/pages/paciente/paciente.ts
+++ b/src/app/pages/paciente/paciente.ts
@@ -157,8 +157,8 @@ function createUniqueValidator(
             </ng-template>
             
             <ng-template #body let-patient>
-                <tr>
-                    <td style="width: 3rem">
+                <tr (click)="showPatientDetails(patient)" style="cursor: pointer;">
+                    <td style="width: 3rem" (click)="$event.stopPropagation()">
                         <p-tableCheckbox [value]="patient" />
                     </td>
                     <td style="min-width: 20rem">{{ patient.nombreCompleto }}</td>
@@ -166,7 +166,7 @@ function createUniqueValidator(
                     <td style="min-width: 12rem">{{ patient.telefono }}</td>
                     <td style="min-width: 16rem">{{ patient.correoElectronico }}</td>
                     <td style="min-width: 10rem">{{ patient.genero }}</td>
-                    <td>
+                    <td (click)="$event.stopPropagation()">
                         <p-button 
                             icon="pi pi-pencil" 
                             class="mr-2" 
@@ -391,6 +391,102 @@ function createUniqueValidator(
             </ng-template>
         </p-dialog>
 
+        <p-dialog 
+            [(visible)]="patientDetailsDialog" 
+            [style]="{ width: '500px' }" 
+            header="Detalles del Paciente" 
+            [modal]="true"
+            [closable]="true"
+        >
+            <ng-template #content>
+                <div class="grid grid-cols-12 gap-4" *ngIf="patient">
+                    <div class="col-span-12">
+                        <div class="bg-gray-50 p-4 rounded-lg">
+                            <div class="text-center mb-6">
+                                    <i class="pi pi-user text-8xl text-blue-500 mb-3 block" style="font-size: 5rem;"></i>
+                                <h3 class="text-xl font-bold text-gray-800">{{ patient.nombreCompleto }}</h3>
+                            </div>
+                            
+                            <div class="grid grid-cols-1 gap-4">
+                                <div class="flex items-center">
+                                    <i class="pi pi-id-card text-gray-600 mr-3"></i>
+                                    <div class="flex flex-col">
+                                        <span class="font-bold text-lg text-gray-800">Cédula</span>
+                                        <span class="text-gray-700">{{ patient.cedula }}</span>
+                                    </div>
+                                </div>
+                                
+                                <div class="flex items-center">
+                                    <i class="pi pi-calendar text-gray-600 mr-3"></i>
+                                    <div class="flex flex-col">
+                                        <span class="font-bold text-lg text-gray-800">Fecha de Nacimiento</span>
+                                        <span class="text-gray-700">{{ patient.fechaNacimiento | date:'dd/MM/yyyy' }}</span>
+                                    </div>
+                                </div>
+                                
+                                <div class="flex items-center">
+                                    <i class="pi pi-users text-gray-600 mr-3"></i>
+                                    <div class="flex flex-col">
+                                        <span class="font-bold text-lg text-gray-800">Género</span>
+                                        <span class="text-gray-700">{{ patient.genero }}</span>
+                                    </div>
+                                </div>
+                                
+                                <div class="flex items-center">
+                                    <i class="pi pi-phone text-gray-600 mr-3"></i>
+                                    <div class="flex flex-col">
+                                        <span class="font-bold text-lg text-gray-800">Teléfono</span>
+                                        <span class="text-gray-700">{{ patient.telefono }}</span>
+                                    </div>
+                                </div>
+                                
+                                <div class="flex items-center">
+                                    <i class="pi pi-envelope text-gray-600 mr-3"></i>
+                                    <div class="flex flex-col">
+                                        <span class="font-bold text-lg text-gray-800">Correo Electrónico</span>
+                                        <span class="text-gray-700">{{ patient.correoElectronico }}</span>
+                                    </div>
+                                </div>
+                                
+                                <div class="flex items-start">
+                                    <i class="pi pi-map-marker text-gray-600 mr-3 mt-2"></i>
+                                    <div class="flex flex-col">
+                                        <span class="font-bold text-lg text-gray-800">Dirección</span>
+                                        <span class="text-gray-700">{{ patient.direccion }}</span>
+                                    </div>
+                                </div>
+                                
+                                <div class="flex items-center" *ngIf="patient.fechaRegistro">
+                                    <i class="pi pi-clock text-gray-600 mr-3"></i>
+                                    <div class="flex flex-col">
+                                        <span class="font-bold text-lg text-gray-800">Fecha de Registro</span>
+                                        <span class="text-gray-700">{{ patient.fechaRegistro | date:'dd/MM/yyyy HH:mm' }}</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </ng-template>
+
+            <ng-template #footer>
+                <div class="flex justify-between w-full">
+                    <p-button 
+                        label="Editar" 
+                        icon="pi pi-pencil" 
+                        severity="secondary"
+                        (click)="editPatientFromDetails()" 
+                    />
+                    <p-button 
+                        label="Cerrar" 
+                        icon="pi pi-times" 
+                        text 
+                        (click)="hideDetailsDialog()" 
+                    />
+                </div>
+            </ng-template>
+        </p-dialog>
+
         <p-confirmdialog [style]="{ width: '450px' }" />
         <p-toast />
     `,
@@ -399,6 +495,7 @@ function createUniqueValidator(
 export class Paciente implements OnInit {
     patientDialog: boolean = false;
     isEditMode: boolean = false;
+    patientDetailsDialog: boolean = false;
     patients = signal<Patient[]>([]);
     patient!: Patient;
     selectedPatients!: Patient[] | null;
@@ -595,6 +692,21 @@ export class Paciente implements OnInit {
         this.patientDialog = false;
         this.submitted = false;
         this.patientForm.reset();
+    }
+
+    showPatientDetails(patient: Patient) {
+        this.patient = { ...patient };
+        this.patientDetailsDialog = true;
+    }
+
+    hideDetailsDialog() {
+        this.patientDetailsDialog = false;
+        this.patient = {} as Patient;
+    }
+
+    editPatientFromDetails() {
+        this.patientDetailsDialog = false;
+        this.editPatient(this.patient);
     }
 
     deletePatient(patient: Patient) {

--- a/src/app/pages/paciente/paciente.ts
+++ b/src/app/pages/paciente/paciente.ts
@@ -193,6 +193,8 @@ function createUniqueValidator(
             [header]="isEditMode ? 'Editar Paciente' : 'Nuevo Paciente'" 
             [modal]="true"
             [closable]="true"
+            [draggable]="false"
+            [resizable]="false"
         >
             <ng-template #content>
                 <form [formGroup]="patientForm" class="flex flex-col gap-4">
@@ -400,6 +402,8 @@ function createUniqueValidator(
             [closable]="true"
             [styleClass]="'patient-details-dialog'"
             [position]="'bottom'"
+            [draggable]="false"
+            [resizable]="false"
         >
             <ng-template #content>
                 <div class="grid grid-cols-12 gap-4" *ngIf="patient">

--- a/src/app/pages/paciente/paciente.ts
+++ b/src/app/pages/paciente/paciente.ts
@@ -113,15 +113,16 @@ function createUniqueValidator(
             [rowsPerPageOptions]="[10, 20, 30]"
         >
             <ng-template #caption>
-                <div class="flex items-center justify-between">
-                    <h5 class="m-0">Gestión de Pacientes</h5>
-                    <p-iconfield>
+                <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
+                    <h5 class="m-0 text-center lg:text-left">Gestión de Pacientes</h5>
+                    <p-iconfield class="w-full lg:w-auto">
                         <p-inputicon styleClass="pi pi-search" />
                         <input 
                             pInputText 
                             type="text" 
                             (input)="onGlobalFilter(dt, $event)" 
                             placeholder="Buscar por nombre, cédula o correo..." 
+                            class="w-full"
                         />
                     </p-iconfield>
                 </div>
@@ -393,10 +394,12 @@ function createUniqueValidator(
 
         <p-dialog 
             [(visible)]="patientDetailsDialog" 
-            [style]="{ width: '500px' }" 
+            [style]="{ width: '500px', height: 'auto', maxHeight: '90vh' }" 
             header="Detalles del Paciente" 
             [modal]="true"
             [closable]="true"
+            [styleClass]="'patient-details-dialog'"
+            [position]="'bottom'"
         >
             <ng-template #content>
                 <div class="grid grid-cols-12 gap-4" *ngIf="patient">
@@ -490,6 +493,31 @@ function createUniqueValidator(
         <p-confirmdialog [style]="{ width: '450px' }" />
         <p-toast />
     `,
+    styles: [`
+        :host ::ng-deep .patient-details-dialog .p-dialog-content {
+            padding: 0;
+            margin: 0;
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        
+        :host ::ng-deep .patient-details-dialog .p-dialog-content > div {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            justify-content: flex-end;
+        }
+        
+        :host ::ng-deep .patient-details-dialog .p-dialog-content .bg-gray-50 {
+            margin-bottom: 0;
+        }
+        
+        :host ::ng-deep .patient-details-dialog .p-dialog-footer {
+            margin-top: 0;
+            padding-top: 1rem;
+        }
+    `],
     providers: [MessageService, PatientService, ConfirmationService]
 })
 export class Paciente implements OnInit {

--- a/src/app/pages/paciente/paciente.ts
+++ b/src/app/pages/paciente/paciente.ts
@@ -204,7 +204,8 @@ interface ExportColumn {
                                 pInputText 
                                 id="cedula" 
                                 formControlName="cedula"
-                                placeholder="Número de cédula"
+                                placeholder="12345678901"
+                                maxlength="13"
                                 [class.ng-invalid]="submitted && patientForm.get('cedula')?.invalid"
                                 fluid 
                             />
@@ -213,6 +214,15 @@ interface ExportColumn {
                                 *ngIf="submitted && patientForm.get('cedula')?.errors?.['required']"
                             >
                                 La cédula es requerida.
+                            </small>
+                            <small 
+                                class="text-red-500" 
+                                *ngIf="submitted && patientForm.get('cedula')?.errors?.['pattern']"
+                            >
+                                La cédula debe tener el formato XXX-XXXXXXX-X (11 dígitos).
+                            </small>
+                            <small class="text-gray-600">
+                                Formato: XXX-XXXXXXX-X (se formatea automáticamente)
                             </small>
                         </div>
                         <div class="col-span-6">
@@ -381,7 +391,7 @@ export class Paciente implements OnInit {
     ) {
         this.patientForm = this.fb.group({
             nombreCompleto: ['', [Validators.required, Validators.minLength(2)]],
-            cedula: ['', [Validators.required, Validators.pattern(/^\d{7,10}$/)]],
+            cedula: ['', [Validators.required, Validators.pattern(/^\d{3}-\d{7}-\d{1}$/)]],
             fechaNacimiento: ['', Validators.required],
             genero: ['', Validators.required],
             direccion: ['', [Validators.required, Validators.minLength(10)]],
@@ -393,6 +403,7 @@ export class Paciente implements OnInit {
     ngOnInit() {
         this.loadPatients();
         this.setupTableColumns();
+        this.setupCedulaFormatting();
     }
 
     loadPatients() {
@@ -414,6 +425,36 @@ export class Paciente implements OnInit {
             title: col.header, 
             dataKey: col.field 
         }));
+    }
+
+    setupCedulaFormatting() {
+        // Escuchar cambios en el campo de cédula para formateo automático
+        this.patientForm.get('cedula')?.valueChanges.subscribe(value => {
+            if (value && typeof value === 'string') {
+                const formattedValue = this.formatCedula(value);
+                const control = this.patientForm.get('cedula');
+                if (control && formattedValue !== value) {
+                    control.setValue(formattedValue, { emitEvent: false });
+                }
+            }
+        });
+    }
+
+    formatCedula(value: string): string {
+        // Remover todos los caracteres que no sean números
+        const numbersOnly = value.replace(/\D/g, '');
+        
+        // Limitar a 11 dígitos máximo
+        const limitedNumbers = numbersOnly.substring(0, 11);
+        
+        // Aplicar formato XXX-XXXXXXX-X
+        if (limitedNumbers.length <= 3) {
+            return limitedNumbers;
+        } else if (limitedNumbers.length <= 10) {
+            return `${limitedNumbers.substring(0, 3)}-${limitedNumbers.substring(3)}`;
+        } else {
+            return `${limitedNumbers.substring(0, 3)}-${limitedNumbers.substring(3, 10)}-${limitedNumbers.substring(10)}`;
+        }
     }
 
     exportCSV() {

--- a/src/app/pages/paciente/paciente.ts
+++ b/src/app/pages/paciente/paciente.ts
@@ -305,19 +305,26 @@ interface ExportColumn {
                     <div class="grid grid-cols-12 gap-4">
                         <div class="col-span-12">
                             <label for="direccion" class="block font-bold mb-2">Dirección *</label>
-                            <p-textarea 
+                            <textarea 
                                 id="direccion" 
+                                pInputText
                                 formControlName="direccion"
                                 placeholder="Ingrese la dirección completa"
                                 rows="3"
                                 [class.ng-invalid]="submitted && patientForm.get('direccion')?.invalid"
-                                fluid
-                            />
+                                style="width: 100%; resize: vertical;"
+                            ></textarea>
                             <small 
                                 class="text-red-500" 
                                 *ngIf="submitted && patientForm.get('direccion')?.errors?.['required']"
                             >
                                 La dirección es requerida.
+                            </small>
+                            <small 
+                                class="text-red-500" 
+                                *ngIf="submitted && patientForm.get('direccion')?.errors?.['minlength']"
+                            >
+                                La dirección debe tener al menos 10 caracteres.
                             </small>
                         </div>
                     </div>

--- a/src/app/pages/pages.routes.ts
+++ b/src/app/pages/pages.routes.ts
@@ -7,7 +7,7 @@ import { Paciente } from './paciente/paciente';
 export default [
     { path: 'documentation', component: Documentation },
     { path: 'crud', component: Crud },
-    { path: 'paciente', component: Paciente },
+    { path: 'pacientes', component: Paciente },
     { path: 'empty', component: Empty },
     { path: '**', redirectTo: '/notfound' }
 ] as Routes;

--- a/src/app/pages/service/patient.service.ts
+++ b/src/app/pages/service/patient.service.ts
@@ -18,7 +18,7 @@ export class PatientService {
         {
             id: '1',
             nombreCompleto: 'Juan Pérez García',
-            cedula: '12345678',
+            cedula: '128-0023456-9',
             fechaNacimiento: new Date('1990-05-15'),
             genero: 'Masculino',
             direccion: 'Calle 123 #45-67, Bogotá',
@@ -29,7 +29,7 @@ export class PatientService {
         {
             id: '2',
             nombreCompleto: 'María González López',
-            cedula: '87654321',
+            cedula: '031-4567890-2',
             fechaNacimiento: new Date('1985-08-22'),
             genero: 'Femenino',
             direccion: 'Carrera 45 #78-90, Medellín',
@@ -40,7 +40,7 @@ export class PatientService {
         {
             id: '3',
             nombreCompleto: 'Carlos Rodríguez Martínez',
-            cedula: '11223344',
+            cedula: '402-0922985-1',
             fechaNacimiento: new Date('1992-12-10'),
             genero: 'Masculino',
             direccion: 'Avenida 80 #12-34, Cali',

--- a/src/app/pages/service/patient.service.ts
+++ b/src/app/pages/service/patient.service.ts
@@ -98,6 +98,42 @@ export class PatientService {
         });
     }
 
+    isNombreCompletoUnique(nombreCompleto: string, excludeId?: string): Promise<boolean> {
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                const exists = this.patients.some(p => 
+                    p.nombreCompleto.toLowerCase() === nombreCompleto.toLowerCase() && 
+                    p.id !== excludeId
+                );
+                resolve(!exists);
+            }, 50);
+        });
+    }
+
+    isCedulaUnique(cedula: string, excludeId?: string): Promise<boolean> {
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                const exists = this.patients.some(p => 
+                    p.cedula === cedula && 
+                    p.id !== excludeId
+                );
+                resolve(!exists);
+            }, 50);
+        });
+    }
+
+    isCorreoElectronicoUnique(correoElectronico: string, excludeId?: string): Promise<boolean> {
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                const exists = this.patients.some(p => 
+                    p.correoElectronico.toLowerCase() === correoElectronico.toLowerCase() && 
+                    p.id !== excludeId
+                );
+                resolve(!exists);
+            }, 50);
+        });
+    }
+
     private generateId(): string {
         let id = '';
         const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';

--- a/src/app/pages/service/patient.service.ts
+++ b/src/app/pages/service/patient.service.ts
@@ -1,0 +1,109 @@
+import { Injectable } from '@angular/core';
+
+export interface Patient {
+    id?: string;
+    nombreCompleto: string;
+    cedula: string;
+    fechaNacimiento: Date;
+    genero: string;
+    direccion: string;
+    telefono: string;
+    correoElectronico: string;
+    fechaRegistro?: Date;
+}
+
+@Injectable()
+export class PatientService {
+    private patients: Patient[] = [
+        {
+            id: '1',
+            nombreCompleto: 'Juan Pérez García',
+            cedula: '12345678',
+            fechaNacimiento: new Date('1990-05-15'),
+            genero: 'Masculino',
+            direccion: 'Calle 123 #45-67, Bogotá',
+            telefono: '3001234567',
+            correoElectronico: 'juan.perez@email.com',
+            fechaRegistro: new Date('2024-01-15')
+        },
+        {
+            id: '2',
+            nombreCompleto: 'María González López',
+            cedula: '87654321',
+            fechaNacimiento: new Date('1985-08-22'),
+            genero: 'Femenino',
+            direccion: 'Carrera 45 #78-90, Medellín',
+            telefono: '3009876543',
+            correoElectronico: 'maria.gonzalez@email.com',
+            fechaRegistro: new Date('2024-01-20')
+        },
+        {
+            id: '3',
+            nombreCompleto: 'Carlos Rodríguez Martínez',
+            cedula: '11223344',
+            fechaNacimiento: new Date('1992-12-10'),
+            genero: 'Masculino',
+            direccion: 'Avenida 80 #12-34, Cali',
+            telefono: '3005555555',
+            correoElectronico: 'carlos.rodriguez@email.com',
+            fechaRegistro: new Date('2024-02-01')
+        }
+    ];
+
+    getPatients(): Promise<Patient[]> {
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                resolve([...this.patients]);
+            }, 100);
+        });
+    }
+
+    createPatient(patient: Patient): Promise<Patient> {
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                const newPatient = {
+                    ...patient,
+                    id: this.generateId(),
+                    fechaRegistro: new Date()
+                };
+                this.patients.push(newPatient);
+                resolve(newPatient);
+            }, 100);
+        });
+    }
+
+    updatePatient(patient: Patient): Promise<Patient> {
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                const index = this.patients.findIndex(p => p.id === patient.id);
+                if (index !== -1) {
+                    this.patients[index] = { ...patient };
+                    resolve(this.patients[index]);
+                }
+                resolve(patient);
+            }, 100);
+        });
+    }
+
+    deletePatient(id: string): Promise<boolean> {
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                const index = this.patients.findIndex(p => p.id === id);
+                if (index !== -1) {
+                    this.patients.splice(index, 1);
+                    resolve(true);
+                }
+                resolve(false);
+            }, 100);
+        });
+    }
+
+    private generateId(): string {
+        let id = '';
+        const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+        for (let i = 0; i < 8; i++) {
+            id += chars.charAt(Math.floor(Math.random() * chars.length));
+        }
+        return id;
+    }
+}

--- a/src/app/pages/uikit/overlaydemo.ts
+++ b/src/app/pages/uikit/overlaydemo.ts
@@ -217,7 +217,7 @@ export class OverlayDemo implements OnInit {
 
     onProductSelect(op: Popover, event: any) {
         op.hide();
-        this.messageService.add({ severity: 'info', summary: 'Product Selected', detail: event?.data.name, life: 3000 });
+        this.messageService.add({ severity: 'info', summary: 'Product Selected', detail: event?.data.name, life: 1500 });
     }
 
     openConfirmation() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app.config';
 import { AppComponent } from './app.component';
+import '@angular/compiler';
 
 bootstrapApplication(AppComponent, appConfig).catch((err) => console.error(err));


### PR DESCRIPTION
Este PR completa la vista de pacientes con datos estáticos que simulan un CRUD.
Se reutilizan componentes del template PrimeNG y se creó un servicio para patients.

Características:
- Formularios con modales para crear, editar, borrar y ver detalles.
- Filtros por cédula, nombre y correo.
- Diseño totalmente responsivo.
- Soporte de tema dark/light y estilos del template (primary, surface, presets).

Nota: Este PR se pasa a la rama `Refactor/DeleteComponents_template`, donde
se eliminarán los componentes no utilizados antes de integrar en `main`.

Vista Previa de los cambios:
/
<img width="1890" height="883" alt="image" src="https://github.com/user-attachments/assets/6bb379a6-6d31-4cb4-8c8e-4c56df3fdc0c" />

/Edit
<img width="1513" height="855" alt="image" src="https://github.com/user-attachments/assets/4e14760a-938a-46fb-9366-ab3d9672ab56" />

/Create
<img width="1327" height="882" alt="image" src="https://github.com/user-attachments/assets/0409fa2c-d53b-4384-9c63-f02ade8687fb" />

/Delete
<img width="890" height="581" alt="image" src="https://github.com/user-attachments/assets/82fd860c-b9c3-4084-ab2b-8e2636961a6a" />

/Dark
<img width="1275" height="910" alt="image" src="https://github.com/user-attachments/assets/56835429-0085-465b-ab26-c81e03f6925d" />

